### PR TITLE
fix: resolve email template path resolution and rebrand to Spoken

### DIFF
--- a/app/modules/meeting/repository.py
+++ b/app/modules/meeting/repository.py
@@ -129,11 +129,7 @@ class MeetingRepository:
         Returns a tuple of (total_count, paginated_records) for meeting history.
         Each record matches the shape needed for `MeetingHistoryItem`.
         """
-        # Base query to get room info, participant count,
-        # and the role of the requesting user.
-        # We join Room with Participant to see the user's
-        # role in that specific room.
-        duration_minutes_expr = self._duration_minutes_expression()
+        _duration_minutes_expr = self._duration_minutes_expression()
 
         base_query = (
             select(


### PR DESCRIPTION
- Corrected template path calculation in `email_consumer.py` to point to the root `templates` directory.
- Added missing `password_changed.html` email template for security notifications.
- Significantly polished `verification.html` with modern, responsive styling.
- Rebranded all transactional email templates from 'FluentMeet' to 'Spoken'.