### PR TITLE
ci: fix production deployment health check loop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,9 +56,15 @@ jobs:
             docker compose -f docker-compose.prod.yml up -d api
 
             echo "==> Waiting for container to be healthy (up to 60s)..."
-            SECONDS=0
-            until [ "$(docker inspect --format='{{.State.Health.Status}}' spoken-api 2>/dev/null)" = "healthy" ] || [ $SECONDS -gt 60 ]; do
+            ITER=0
+            while [ $ITER -lt 12 ]; do
+              STATUS=$(docker inspect --format='{{.State.Health.Status}}' spoken-api 2>/dev/null || echo "starting")
+              echo "==> Current status: $STATUS"
+              if [ "$STATUS" = "healthy" ]; then
+                break
+              fi
               sleep 5
+              ITER=$((ITER + 1))
             done
 
             STATUS=$(docker inspect --format='{{.State.Health.Status}}' spoken-api 2>/dev/null || echo "unknown")

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -66,6 +66,12 @@ services:
         condition: service_healthy
     ports:
       - "8000:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     networks:
       - spoken-net
 


### PR DESCRIPTION
- Refactor deploy.yml health check to use a portable while loop, fixing a syntax error caused by the bash-specific $SECONDS variable in non-bash shells.
- Add explicit healthcheck configuration to docker-compose.prod.yml for the api service to ensure consistent health monitoring.
- Improve deployment logging by printing the container status during the wait period.