### PR TITLE
refactor: change auth token primary keys to UUID

### DIFF
--- a/alembic/versions/5421608b7a60_change_auth_token_ids_to_uuid.py
+++ b/alembic/versions/5421608b7a60_change_auth_token_ids_to_uuid.py
@@ -1,0 +1,44 @@
+"""change_auth_token_ids_to_uuid
+
+Revision ID: 5421608b7a60
+Revises: c10f646cb60e
+Create Date: 2026-05-05 11:47:39.676258
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "5421608b7a60"
+down_revision: Union[str, Sequence[str], None] = "c10f646cb60e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Ensure extension exists
+    op.execute('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"')
+
+    # Drop defaults and alter types with conversion
+    op.execute("ALTER TABLE verification_tokens ALTER COLUMN id DROP DEFAULT")
+    op.execute(
+        "ALTER TABLE verification_tokens ALTER COLUMN id TYPE uuid USING (uuid_generate_v4())"
+    )
+
+    op.execute("ALTER TABLE password_reset_tokens ALTER COLUMN id DROP DEFAULT")
+    op.execute(
+        "ALTER TABLE password_reset_tokens ALTER COLUMN id TYPE uuid USING (uuid_generate_v4())"
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Note: downgrading back to serial/int is non-trivial if UUIDs were generated.
+    op.execute("ALTER TABLE verification_tokens ALTER COLUMN id TYPE integer USING (1)")
+    op.execute(
+        "ALTER TABLE password_reset_tokens ALTER COLUMN id TYPE integer USING (1)"
+    )

--- a/app/modules/auth/models.py
+++ b/app/modules/auth/models.py
@@ -76,7 +76,7 @@ class VerificationToken(Base):
     """Model representing a verification token for email verification or password reset.
 
     Attributes:
-        id (int): Primary key identifier for the token.
+        id (uuid.UUID): Primary key identifier for the token.
         user_id (uuid.UUID): Foreign key referencing the associated user.
         token (str): Unique token string used for verification.
         expires_at (datetime): Timestamp indicating when the token expires.
@@ -84,8 +84,9 @@ class VerificationToken(Base):
     """
 
     __tablename__ = "verification_tokens"
-
-    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, index=True, default=uuid.uuid4
+    )
     user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
     token: Mapped[str] = mapped_column(
         String(36),
@@ -106,7 +107,7 @@ class PasswordResetToken(Base):
     """Model representing a password reset token.
 
     Attributes:
-        id (int): Primary key identifier for the token.
+        id (uuid.UUID): Primary key identifier for the token.
         user_id (uuid.UUID): Foreign key referencing the associated user.
         token (str): Unique token string used for password reset.
         expires_at (datetime): Timestamp indicating when the token expires.
@@ -114,8 +115,9 @@ class PasswordResetToken(Base):
     """
 
     __tablename__ = "password_reset_tokens"
-
-    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True, index=True, default=uuid.uuid4
+    )
     user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
     token: Mapped[str] = mapped_column(
         String(36),


### PR DESCRIPTION
- Update VerificationToken and PasswordResetToken models to use UUID primary keys for improved security and consistency.
- Generate Alembic migration with safe PostgreSQL type conversion using 'USING' clause and 'uuid_generate_v4()'.
- Update model docstrings to reflect the schema changes.