### PR TITLE
fix(signaling): inject from_user_id into all relayed WebRTC messages

### DIFF
--- a/app/modules/meeting/ws_router.py
+++ b/app/modules/meeting/ws_router.py
@@ -94,6 +94,11 @@ async def signaling_websocket(
                 payload = json.loads(data)
                 target_user_id = payload.get("target_user_id")
 
+                # Always inject the sender's identity so the recipient knows
+                # who sent the offer/answer/ice_candidate. Without this,
+                # from_user_id is undefined on the frontend.
+                payload["from_user_id"] = user_id
+
                 # If target specified, unicast. Otherwise, broadcast.
                 if target_user_id:
                     await manager.send_to_user(room_code, target_user_id, payload)

--- a/tests/meeting/test_ws_router.py
+++ b/tests/meeting/test_ws_router.py
@@ -86,7 +86,9 @@ def test_signaling_websocket(mock_connection_manager):
 
     mock_connection_manager.connect.assert_called_once()
     mock_connection_manager.send_to_user.assert_called_once_with(
-        "room1", "user2", {"type": "offer", "target_user_id": "user2"}
+        "room1",
+        "user2",
+        {"type": "offer", "target_user_id": "user2", "from_user_id": "user1"},
     )
     mock_connection_manager.disconnect.assert_called_once_with("room1", "user1")
     assert mock_connection_manager.broadcast_to_room.call_count == 2


### PR DESCRIPTION
The backend was forwarding raw payloads without adding the sender's identity, causing the frontend to receive offers/answers with from_user_id = undefined. This silently dropped all WebRTC handshakes, preventing media from flowing between participants.