### PR TITLE
fix(docker): align builder and runtime workdir to resolve shebang paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================
 FROM python:3.11-slim AS builder
 
-WORKDIR /build
+WORKDIR /app
 
 # Copy uv binary from the official image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -33,7 +33,7 @@ RUN groupadd -r appuser && useradd -r -g appuser appuser
 WORKDIR /app
 
 # Copy the virtual environment from the builder
-COPY --from=builder /build/.venv /app/.venv
+COPY --from=builder /app/.venv /app/.venv
 
 # Copy application source
 COPY pyproject.toml ./


### PR DESCRIPTION
Change builder stage WORKDIR from `/build` to `/app` to ensure virtual environment script shebangs (like `uvicorn`) resolve to valid absolute paths in the final runtime container.