### PR TITLE
fix(healthcheck): force IPv4 127.0.0.1 for API healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ USER appuser
 EXPOSE 8000
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+    CMD curl -f http://127.0.0.1:8000/health || exit 1
 
 # Run using the python interpreter inside the virtual environment
 ENV PATH="/app/.venv/bin:$PATH"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -65,7 +65,7 @@ services:
     ports:
       - "8000:8000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/health"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Change healthcheck targets from `localhost` to `127.0.0.1` in Dockerfile and docker-compose.prod.yml to prevent curl connection failures when localhost resolves to IPv6 loopback (::1).